### PR TITLE
Adds the ability to get all corralled features

### DIFF
--- a/corral.gemspec
+++ b/corral.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "pry", "~> 0.10.4"
 end

--- a/lib/corral/feature.rb
+++ b/lib/corral/feature.rb
@@ -8,21 +8,30 @@ module Corral
       @disabled = disabled
     end
 
-    def self.push(name, condition, disabled = true)
-      @features ||= {}
-      @features[name] = new(name, condition, disabled)
-    end
+    class << self
+      def features
+        @features ||= {}
+      end
 
-    def self.enable(name, condition)
-      push(name, condition, false)
-    end
+      def push(name, condition, disabled = true)
+        features[name] = new(name, condition, disabled)
+      end
 
-    def self.disable(name, condition)
-      push(name, condition, true)
-    end
+      def enable(name, condition)
+        push(name, condition, false)
+      end
 
-    def self.get(name)
-      (@features ||= {})[name]
+      def disable(name, condition)
+        push(name, condition, true)
+      end
+
+      def get(name)
+        features[name]
+      end
+
+      def all
+        features
+      end
     end
   end
 end

--- a/lib/corral/version.rb
+++ b/lib/corral/version.rb
@@ -1,3 +1,3 @@
 module Corral
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/corral/feature_spec.rb
+++ b/spec/corral/feature_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Corral::Feature do
+  include Corral::Helpers
+
+  describe ".all" do
+    context "when no features have been corralled" do
+      it "is an empty hash" do
+        expect(Corral::Feature.all).to eq({})
+      end
+    end
+
+    context "when one or more features have been corralled" do
+      before do
+        corral do
+          enable :everything_free
+          disable :torpedoes
+        end
+      end
+
+      it "is list of every feature" do
+        expect(Corral::Feature.all.keys).to eq([:everything_free, :torpedoes])
+      end
+    end
+  end
+end

--- a/spec/corral_spec.rb
+++ b/spec/corral_spec.rb
@@ -6,7 +6,7 @@ describe Corral do
   describe ".corral" do
     context "when given a block" do
       it "yields the block" do
-        corral { :cool_feature }.should == :cool_feature
+        expect(corral { :cool_feature }).to eq(:cool_feature)
       end
 
       context "when given known features" do
@@ -20,8 +20,8 @@ describe Corral do
             end
 
             it "disables the feature" do
-              disabled?(:caching).should be_true
-              enabled?("expiry_headers").should be_true
+              expect(disabled?(:caching)).to be true
+              expect(enabled?("expiry_headers")).to be true
             end
           end
 
@@ -33,7 +33,7 @@ describe Corral do
             end
 
             it "does not disable the feature" do
-              disabled?(:debug_mode).should be_false
+              expect(disabled?(:debug_mode)).to be false
             end
           end
         end
@@ -48,8 +48,8 @@ describe Corral do
             end
 
             it "is disabled" do
-              disabled?(:everything_free).should be_true
-              disabled?(:torpedoes).should be_true
+              expect(disabled?(:everything_free)).to be true
+              expect(disabled?(:torpedoes)).to be true
             end
           end
 
@@ -62,8 +62,8 @@ describe Corral do
             end
 
             it "is enabled" do
-              enabled?(:payment_button).should be_true
-              enabled?(:sunshine).should be_true
+              expect(enabled?(:payment_button)).to be true
+              expect(enabled?(:sunshine)).to be true
             end
           end
         end
@@ -81,7 +81,7 @@ describe Corral do
         context "when not given a 'when' or 'if' condition" do
           it "is disabled" do
             corral { :my_feature }
-            disabled?(:my_feature).should be_true
+            expect(disabled?(:my_feature)).to be true
           end
         end
       end
@@ -104,7 +104,7 @@ describe Corral do
         end
 
         it "is false" do
-          enabled?(:torpedoes).should be_false
+          expect(enabled?(:torpedoes)).to be false
         end
       end
 
@@ -117,7 +117,7 @@ describe Corral do
           end
 
           it "is false" do
-            enabled?(:torpedoes).should be_false
+            expect(enabled?(:torpedoes)).to be false
           end
         end
 
@@ -129,7 +129,7 @@ describe Corral do
           end
 
           it "is true" do
-            enabled?(:cupcakes).should be_true
+            expect(enabled?(:cupcakes)).to be true
           end
         end
       end
@@ -137,7 +137,7 @@ describe Corral do
 
     context "when the given feature does not exist" do
       it "is false" do
-        enabled?(:unknown_feature).should be_false
+        expect(enabled?(:unknown_feature)).to be false
       end
     end
 
@@ -150,7 +150,7 @@ describe Corral do
         end
 
         it "is false" do
-          enabled?(:cupcakes, "Bryan").should be_false
+          expect(enabled?(:cupcakes, "Bryan")).to be false
         end
       end
 
@@ -162,7 +162,7 @@ describe Corral do
         end
 
         it "is false" do
-          enabled?(:cupcakes, "George").should be_true
+          expect(enabled?(:cupcakes, "George")).to be true
         end
       end
     end
@@ -178,7 +178,7 @@ describe Corral do
         end
 
         it "is true" do
-          disabled?(:torpedoes).should be_true
+          expect(disabled?(:torpedoes)).to be true
         end
       end
 
@@ -191,7 +191,7 @@ describe Corral do
           end
 
           it "is true" do
-            disabled?(:torpedoes).should be_true
+            expect(disabled?(:torpedoes)).to be true
           end
         end
 
@@ -203,7 +203,7 @@ describe Corral do
           end
 
           it "is false" do
-            disabled?(:cupcakes).should be_false
+            expect(disabled?(:cupcakes)).to be false
           end
         end
       end
@@ -211,7 +211,7 @@ describe Corral do
 
     context "when the given feature does not exist" do
       it "is true" do
-        disabled?(:unknown_feature).should be_true
+        expect(disabled?(:unknown_feature)).to be true
       end
     end
   end
@@ -225,7 +225,7 @@ describe Corral do
       end
 
       it "is true" do
-        disabled?(:cupcakes, "Bryan").should be_true
+        expect(disabled?(:cupcakes, "Bryan")).to be true
       end
     end
 
@@ -237,7 +237,7 @@ describe Corral do
       end
 
       it "is false" do
-        disabled?(:cupcakes, "George").should be_false
+        expect(disabled?(:cupcakes, "George")).to be false
       end
     end
   end
@@ -252,8 +252,8 @@ describe Corral do
       end
 
       it "enables the feature" do
-        enabled?(:always_on).should be_true
-        disabled?(:everything).should be_false
+        expect(enabled?(:always_on)).to be true
+        expect(disabled?(:everything)).to be false
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'corral'
+require 'pry'


### PR DESCRIPTION
Corral::Feature.all returns a hash of all the features

This might be helpful if you need to return a list of all the features
enabled for a given user, for example.

Made the tests RSpec 3 compatible

Refactored Corral::Feature a little to look a little nicer